### PR TITLE
feat: add optional --project flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ ng generate ngx-cli-toolkit:init
 ```
 
 **Example for an Angular library project:**
+
+Inside Angular workspaces, the `--project` flag can be used to locate the root directory of a project.
+
 ```shell
 ng generate library awesome-library
-cd projects/awesome-library
-ng generate ngx-cli-toolkit:init
+ng generate ngx-cli-toolkit:init --project awesome-library
 ```
 
 ### Generating `ng-add` 

--- a/src/ng-generate/init/index.spec.ts
+++ b/src/ng-generate/init/index.spec.ts
@@ -93,6 +93,7 @@ describe('ng-generate', () => {
 
     let tree: Tree;
     let runner: SchematicTestRunner;
+    let options: InitSchematicsProjectOptions;
     const projectUiPackageJsonPath = path.join(angularJson.projects.ui.root, 'package.json');
     const schematicsDirectoryPath = path.join(angularJson.projects.ui.root, 'schematics');
 
@@ -102,13 +103,13 @@ describe('ng-generate', () => {
         tree.create('angular.json', JSON.stringify(angularJson));
         tree.create(projectUiPackageJsonPath, JSON.stringify(packageJson));
 
-        const options: InitSchematicsProjectOptions = {
+        options = {
             path: `${angularJson.projects.ui.root}/subdirectory` as string,
         };
-        await runner.runSchematicAsync('init', options, tree).toPromise();
     });
 
-    it('should create migrations.json', () => {
+    it('should create migrations.json', async () => {
+        await runner.runSchematicAsync('init', options, tree).toPromise();
         const expectedMigrationsJson = {
             $schema: '../../../node_modules/@angular-devkit/schematics/collection-schema.json',
             schematics: {},
@@ -117,7 +118,8 @@ describe('ng-generate', () => {
         expect(JSON.parse(migrationJson)).toMatchObject(expectedMigrationsJson);
     });
 
-    it('should create collection.json', () => {
+    it('should create collection.json', async () => {
+        await runner.runSchematicAsync('init', options, tree).toPromise();
         const expectedCollectionJson = {
             $schema: '../../../node_modules/@angular-devkit/schematics/collection-schema.json',
             schematics: {},
@@ -132,7 +134,14 @@ describe('ng-generate', () => {
     //     expect(JSON.parse(tree.read('angular.json')?.toString('utf8')!)).toStrictEqual(angularJsonExpected);
     // });
 
-    it('should add schematics entries in package.json', () => {
+    it('should add schematics entries in package.json', async () => {
+        await runner.runSchematicAsync('init', options, tree).toPromise();
+        expect(JSON.parse(tree.read(projectUiPackageJsonPath)?.toString('utf8')!)).toStrictEqual(packageJsonExpected);
+    });
+
+    it('should init project with the --project flag', async () => {
+        let _options = { project: 'ui', path: '/' as string };
+        await runner.runSchematicAsync('init', _options, tree).toPromise();
         expect(JSON.parse(tree.read(projectUiPackageJsonPath)?.toString('utf8')!)).toStrictEqual(packageJsonExpected);
     });
 });

--- a/src/ng-generate/init/index.ts
+++ b/src/ng-generate/init/index.ts
@@ -1,16 +1,21 @@
 import { chain, noop, SchematicsException, Tree } from '@angular-devkit/schematics';
-import { updateWorkspace } from '@schematics/angular/utility/workspace';
+import { getWorkspace, updateWorkspace } from '@schematics/angular/utility/workspace';
 import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import * as path from 'path';
-import { findPackageJson, getParsedPath, removeLastSegmentOfPath } from "../../utils/utils";
+import { findPackageJson, getParsedPath, getProject, removeLastSegmentOfPath } from "../../utils/utils";
 import { Location } from '@schematics/angular/utility/parse-name';
 
 export interface InitSchematicsProjectOptions {
     path: string;
+    project?: string;
 }
 
 export function initSchematicsProject(options: InitSchematicsProjectOptions) {
     return async (host: Tree) => {
+        if(options.project) {
+            const workspace = await getWorkspace(host);
+            options.path = (await getProject(workspace, options.project)).root;
+        }
         const parsedPath = getParsedPath(options.path, 'schematics');
         const projectRoot = removeLastSegmentOfPath(findPackageJson(host, parsedPath));
         const schematicsDir = path.join(projectRoot, parsedPath.name);

--- a/src/ng-generate/init/schema.json
+++ b/src/ng-generate/init/schema.json
@@ -5,6 +5,11 @@
       "format": "path",
       "description": "",
       "visible": false
+    },
+    "project": {
+      "type": "string",
+      "description": "Name of the Angular project",
+      "minLength": 1
     }
   }
 }


### PR DESCRIPTION
This PR adds optional support for `--project %project-name%` for `ngx-cli-toolkit:{init,update,generate,add}`.
If `--project` is not set it falls back to the default behaviour (you must be in the project directory before running the schematic)